### PR TITLE
Correct shutdown behaviour

### DIFF
--- a/image/start.sh
+++ b/image/start.sh
@@ -20,4 +20,4 @@ echo "Starting Tailscale"
 
 export TS_EXTRA_ARGS=--hostname="${TS_HOSTNAME} ${TS_EXTRA_ARGS}"
 echo "Note: set TS_EXTRA_ARGS to " $TS_EXTRA_ARGS
-/usr/local/bin/containerboot
+exec /usr/local/bin/containerboot


### PR DESCRIPTION
The last step of `start.sh` is now to `exec` directly into `containerboot`. This means that exit signals correctly propagate when a container is shutdown. This is especially important when using `--state:mem`, as it forces an ephemeral node to shutdown and remove itself, meaning subsequent container starts can use the same machine name (see https://github.com/tailscale/tailscale/issues/4778#issuecomment-1229366518 for more information on this specific use case).